### PR TITLE
Development

### DIFF
--- a/src/tartarus/readers.cpp
+++ b/src/tartarus/readers.cpp
@@ -21,18 +21,15 @@ namespace readers
         }
 
         // get file size in bytes
-        uint32_t file_size = std::filesystem::file_size(path); 
+        uint32_t file_size = std::filesystem::file_size(path);
 
-        uint8_t* cdata = new uint8_t[file_size];
+        std::vector<uint8_t> data(file_size);
 
-        if(fread(cdata, sizeof(uint8_t), file_size, fptr) != file_size)
+        if (fread(data.data(), sizeof(uint8_t), file_size, fptr) != file_size)
         {
-	    delete[] cdata;
-            throw std::runtime_error("could not read the file");
+            throw std::runtime_error("could not read the file: " + path);
         }
 
-        std::vector<uint8_t> data(cdata, cdata + file_size);
-	delete[] cdata;
 	fclose(fptr);
 	
         return data;

--- a/src/tartarus/readers.cpp
+++ b/src/tartarus/readers.cpp
@@ -20,7 +20,7 @@ namespace readers
             throw std::runtime_error("Could not open the file");
         }
 
-        // get file size in bytes
+        // File size in bytes
         uint32_t file_size = std::filesystem::file_size(path);
 
         std::vector<uint8_t> data(file_size);

--- a/test/writers_and_readers/test_writers_and_readers.cpp
+++ b/test/writers_and_readers/test_writers_and_readers.cpp
@@ -10,39 +10,26 @@
 #include <algorithm>
 #include <cstdint>
 
-// TEST(test_read_json, read_json)
-// {
-//   std::string file_path = "test/files/json/test.json";
-//   auto json_data = tartarus::readers::json_reader(file_path);
 
-//   std::string info_string = json_data.value("info", "failure");
+TEST(test_vector_write_reader, writer_and_reader)
+{
 
-//   int version = json_data.value("version", 0);
-  
-//   EXPECT_EQ(info_string, "Test of json reader");
-//   EXPECT_EQ(version, 1);
- 
-// }
+    std::vector<uint8_t> data(4096);
+    std::generate(std::begin(data), std::end(data), rand);
 
-// TEST(test_disk_vector_reader_writer, reader_and_writer)
-// {
-//     srand(static_cast<uint32_t>(time(0)));
-//     std::vector<uint8_t> data_out(1024);
-//     std::generate(data_out.begin(), data_out.end(), rand);
+    std::string path = "test_out/out.bin";
 
-//     std::string path = "./TEST_DATA";
-//     auto result = tartarus::writers::vector_disk_writer(path, data_out);
-//     EXPECT_TRUE(result);
+    EXPECT_TRUE(tartarus::writers::vector_disk_writer(path, data));
 
-//     auto data_in = tartarus::readers::vector_disk_reader(path);
-//     EXPECT_EQ(data_out, data_in);    
-// }
+    auto read_data = tartarus::readers::vector_disk_reader(path);
+    EXPECT_EQ(data, read_data);     
+}
 
 TEST(test_bjson_reader_writer, reader_and_writer)
 {
     nlohmann::json obj;
     obj["test"] = "test";
-    std::string path = "/test_out/out.bjson";
+    std::string path = "test_out/out.bjson";
     tartarus::writers::bjson_writer(path, obj);
     auto inobj = tartarus::readers::bjson_reader(path);
     EXPECT_EQ(obj["test"].get<std::string>(), inobj["test"].get<std::string>());
@@ -52,7 +39,7 @@ TEST(test_ubjson_reader_writer, reader_and_writer)
 {
     nlohmann::json obj;
     obj["test"] = "test";
-    std::string path = "/test_out/out.ubjson";
+    std::string path = "test_out/out.ubjson";
     tartarus::writers::ubjson_writer(path, obj);
     auto inobj = tartarus::readers::ubjson_reader(path);
     EXPECT_EQ(obj["test"].get<std::string>(), inobj["test"].get<std::string>());
@@ -62,7 +49,7 @@ TEST(test_cbor_reader_writer, reader_and_writer)
 {
     nlohmann::json obj;
     obj["test"] = "test";
-    std::string path = "/test_out/out.cbor";
+    std::string path = "test_out/out.cbor";
     tartarus::writers::cbor_writer(path, obj);
     auto inobj = tartarus::readers::cbor_reader(path);
     EXPECT_EQ(obj["test"].get<std::string>(), inobj["test"].get<std::string>());
@@ -72,13 +59,14 @@ TEST(test_msgpack_reader_writer, reader_and_writer)
 {
     nlohmann::json obj;
     obj["test"] = "test";
-    std::string path = "/test_out/out.ubjson";
+    std::string path = "test_out/out.ubjson";
     tartarus::writers::msgpack_writer(path, obj);
     auto inobj = tartarus::readers::msgpack_reader(path);
     EXPECT_EQ(obj["test"].get<std::string>(), inobj["test"].get<std::string>());
 }
 
 int main(int argc, char **argv) {
+    srand(static_cast<uint32_t>(time(0)));
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }

--- a/wscript
+++ b/wscript
@@ -3,6 +3,8 @@
 from waflib.Tools.compiler_cxx import cxx_compiler
 from scripts.waf import utils
 
+import subprocess
+
 import sys
 import os
 
@@ -90,6 +92,7 @@ def doc(dc):
 # @param base_dir your test folder 
 def run_tests(base_dir):
 
+    os.mkdir('test_out')
     platform = sys.platform
     if not base_dir.endswith('/'):
         base_dir = base_dir + '/'
@@ -103,6 +106,7 @@ def run_tests(base_dir):
             if not proc.endswith('.o'):
                 cproc = './' + current_dir + '/' + proc
                 os.system(cproc)
+    subprocess.call(['rm', '-r', 'test_out'], encoding='utf-8')
 
 # Generate documentation for
 # @param doc_tool the name of the document tool command


### PR DESCRIPTION
Removed a temp `uint8_t*` and resulting `std::memcpy` from the read function should speed up the reading process even more and reduce memory usage for each function call. 

Additionally, I added test cases for the vector reader and writer and fixed broken test cases readers and writers due to broken paths and I added a setup and create and remove folder call in the wscript file for test to create the test directories. 